### PR TITLE
Missions profile

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -12,7 +12,7 @@ import { getRockets } from './redux/rockets/rocketsSlice';
 import { getMissions } from './redux/missions/missionsSlice';
 import store from './redux/configureStore';
 import MyProfile from './pages/MyProfile';
-// import 'bootstrap/dist/css/bootstrap.min.css';
+import 'bootstrap/dist/css/bootstrap.min.css';
 
 const App = () => {
   useEffect(() => {

--- a/src/components/missions/MissionRowTable.js
+++ b/src/components/missions/MissionRowTable.js
@@ -10,9 +10,9 @@ const MissionRowTable = (props) => {
   return (
     <tr>
       <td className="fs-5 fw-bold">{missionName}</td>
-      <td>{description}</td>
-      {reserved ? <td className="badge rounded-pill bg-primary text-light">MEMBER</td> : <td className="badge rounded-pill bg-secondary text-light">NOT A MEMBER</td>}
-      <td><button className={(reserved) ? 'btn btn-outline-danger' : 'btn btn-outline-secondary'} type="button" onClick={() => store.dispatch(removeMission(missionId))}>{(reserved) ? 'Leave Mission' : 'Join Mission'}</button></td>
+      <td className="p-2">{description}</td>
+      {reserved ? <td className="badge rounded-pill bg-primary text-light m-2">MEMBER</td> : <td className="badge rounded-pill bg-secondary text-light m-2">NOT A MEMBER</td>}
+      <td><button className={(reserved) ? 'btn btn-outline-danger m-2' : 'btn btn-outline-secondary m-2'} type="button" onClick={() => store.dispatch(removeMission(missionId))}>{(reserved) ? 'Leave Mission' : 'Join Mission'}</button></td>
     </tr>
   );
 };

--- a/src/components/missions/MissionsList.js
+++ b/src/components/missions/MissionsList.js
@@ -1,7 +1,0 @@
-const MissionsList = () => (
-  <div>
-    <h1>PAGE UNDER CONSTRUCTION</h1>
-  </div>
-);
-
-export default MissionsList;

--- a/src/components/missions/MissionsTable.js
+++ b/src/components/missions/MissionsTable.js
@@ -7,9 +7,9 @@ const MissionsTable = () => {
 
   return (
     <div>
-      <table className="table table-striped table-hover">
+      <table className="table table-striped table-hover table-bordered">
         <tr className="fs-5">
-          <th>Mission</th>
+          <th className="p-2">Mission</th>
           <th>Description</th>
           <th>Status</th>
           <th> </th>

--- a/src/components/missions/ReservedMissions.js
+++ b/src/components/missions/ReservedMissions.js
@@ -1,0 +1,16 @@
+import { PropTypes } from 'prop-types';
+
+const MissionReserved = (props) => {
+  const { missionName } = props;
+  return (
+    <tr>
+      <td className="p-3 pb-4">{missionName}</td>
+    </tr>
+  );
+};
+
+MissionReserved.propTypes = {
+  missionName: PropTypes.string.isRequired,
+};
+
+export default MissionReserved;

--- a/src/components/missions/ReservedMissionsList.js
+++ b/src/components/missions/ReservedMissionsList.js
@@ -1,0 +1,22 @@
+import { useSelector } from 'react-redux';
+import { v4 as uuidv4 } from 'uuid';
+import ReservedMissions from './ReservedMissions';
+
+const ReservedMissionsList = () => {
+  const missions = useSelector((state) => state.missions);
+  const reserved = missions.data.filter((missions) => missions.reserved);
+
+  return (
+    <table className="table table-bordered rounded">
+      <tbody>
+        {
+          reserved.map((mission) => (
+            <ReservedMissions key={uuidv4()} missionName={mission.mission_name} />
+          ))
+        }
+      </tbody>
+    </table>
+  );
+};
+
+export default ReservedMissionsList;

--- a/src/pages/MyProfile.js
+++ b/src/pages/MyProfile.js
@@ -1,4 +1,5 @@
 import ReservedRockets from '../components/rockets/ReservedRocketsList';
+import ReservedMissionsList from '../components/missions/ReservedMissionsList';
 import MyProfileStyles from './MyProfile.module.css';
 
 const MyProfile = () => (
@@ -6,6 +7,7 @@ const MyProfile = () => (
     <div className={MyProfileStyles.pageContainer}>
       <div className={MyProfileStyles.missionsContainer}>
         <h2 className={MyProfileStyles.title}>My Missions</h2>
+        <ReservedMissionsList />
       </div>
       <div className={MyProfileStyles.rocketsContainer}>
         <h2 className={MyProfileStyles.title}>My Rockets</h2>


### PR DESCRIPTION
# Display joined missions in My profile - Filters #2

In this pull request, I've been working on adding the reserved missions as a table in the "My Profile" page:

- [x] - Render a list of all joined missions (use `filter()`) on the "My profile" page.
- [x] - Fix linters.