### PR TITLE
Add aditional requirements in my-profile page

### DIFF
--- a/src/components/missions/ReservedMissions.js
+++ b/src/components/missions/ReservedMissions.js
@@ -1,16 +1,25 @@
 import { PropTypes } from 'prop-types';
+import ReservedMissionsStyle from './ReservedMissions.module.css';
+import store from '../../redux/configureStore';
+import { removeMission } from '../../redux/missions/missionsSlice';
 
 const ReservedMissions = (props) => {
-  const { missionName } = props;
+  const { missionName, missionId, wikipedia } = props;
   return (
     <tr>
-      <td className="p-3 pb-4">{missionName}</td>
+      <td className="p-3 pb-4">
+        {missionName}
+        <button type="button" className={ReservedMissionsStyle.cancelReservationButton} onClick={() => store.dispatch(removeMission(missionId))}>Leave Mission</button>
+        <button type="button" className={ReservedMissionsStyle.reserveButton} onClick={() => window.open(wikipedia)}>Read More</button>
+      </td>
     </tr>
   );
 };
 
 ReservedMissions.propTypes = {
   missionName: PropTypes.string.isRequired,
+  missionId: PropTypes.string.isRequired,
+  wikipedia: PropTypes.string.isRequired,
 };
 
 export default ReservedMissions;

--- a/src/components/missions/ReservedMissions.module.css
+++ b/src/components/missions/ReservedMissions.module.css
@@ -1,20 +1,3 @@
-.rocketItem {
-  padding: 0.5rem 0.5rem 1rem 0.5rem;
-}
-
-.container {
-  width: 100%;
-  border-bottom: 1px solid lightgray;
-}
-
-.container:nth-child(even) {
-  border-bottom: 2px solid lightgray;
-}
-
-.container:last-child {
-  border-bottom: none;
-}
-
 .cancelReservationButton {
   padding: 0.2rem 1rem;
   border-radius: 5px;

--- a/src/components/missions/ReservedMissionsList.js
+++ b/src/components/missions/ReservedMissionsList.js
@@ -1,21 +1,31 @@
 import { useSelector } from 'react-redux';
 import { v4 as uuidv4 } from 'uuid';
 import ReservedMissions from './ReservedMissions';
+import ReservedMissionsStyles from './ReservedMissionsList.module.css';
 
 const ReservedMissionsList = () => {
   const missions = useSelector((state) => state.missions);
   const reserved = missions.data.filter((missions) => missions.reserved);
 
   return (
-    <table className="table table-bordered rounded">
-      <tbody>
-        {
+    <>
+      { reserved.length === 0
+      && <p className={ReservedMissionsStyles.title}>&emsp; Join a Mission First</p>}
+      <table className="table table-bordered rounded">
+        <tbody>
+          {
           reserved.map((mission) => (
-            <ReservedMissions key={uuidv4()} missionName={mission.mission_name} />
+            <ReservedMissions
+              key={uuidv4()}
+              missionName={mission.mission_name}
+              missionId={mission.mission_id}
+              wikipedia={mission.wikipedia}
+            />
           ))
         }
-      </tbody>
-    </table>
+        </tbody>
+      </table>
+    </>
   );
 };
 

--- a/src/components/missions/ReservedMissionsList.module.css
+++ b/src/components/missions/ReservedMissionsList.module.css
@@ -1,0 +1,5 @@
+.title {
+  font-size: 20px;
+  font-weight: 700;
+  padding-bottom: 0.5rem;
+}

--- a/src/components/rockets/ReservedRocket.js
+++ b/src/components/rockets/ReservedRocket.js
@@ -1,18 +1,26 @@
 /* eslint-disable camelcase */
 import { PropTypes } from 'prop-types';
 import ReservedRocketStyle from './ReservedRocket.module.css';
+import store from '../../redux/configureStore';
+import { removeRocket } from '../../redux/rockets/rocketsSlice';
 
 const ReservedRocket = (props) => {
-  const { rocket_name } = props;
+  const { rocket_name, rocket_id, wikipedia } = props;
   return (
     <div className={ReservedRocketStyle.container}>
-      <p className={ReservedRocketStyle.rocketItem}>{rocket_name}</p>
+      <p className={ReservedRocketStyle.rocketItem}>
+        {rocket_name}
+        <button className={ReservedRocketStyle.cancelReservationButton} type="button" onClick={() => store.dispatch(removeRocket(rocket_id))}>Cancel Reservation</button>
+        <button type="button" className={ReservedRocketStyle.reserveButton} onClick={() => window.open(wikipedia)}>Cancel Reservation</button>
+      </p>
     </div>
   );
 };
 
 ReservedRocket.propTypes = {
   rocket_name: PropTypes.string.isRequired,
+  rocket_id: PropTypes.string.isRequired,
+  wikipedia: PropTypes.string.isRequired,
 };
 
 export default ReservedRocket;

--- a/src/components/rockets/ReservedRocketsList.js
+++ b/src/components/rockets/ReservedRocketsList.js
@@ -9,9 +9,16 @@ const ReservedRockets = () => {
 
   return (
     <div className={(reserved.length > 0) ? ReservedRocketsListStyle.listContainer : ''}>
+      { reserved.length === 0
+      && <p className={ReservedRocketsListStyle.title}>&emsp; Reserve a Rocket First </p> }
       {
       reserved.map((rocket) => (
-        <ReservedRocket key={uuidv4()} rocket_name={rocket.rocket_name} />
+        <ReservedRocket
+          key={uuidv4()}
+          rocket_id={rocket.rocket_id}
+          rocket_name={rocket.rocket_name}
+          wikipedia={rocket.wikipedia}
+        />
       ))
     }
     </div>

--- a/src/components/rockets/ReservedRocketsListStyle.module.css
+++ b/src/components/rockets/ReservedRocketsListStyle.module.css
@@ -4,3 +4,9 @@
   border: 1px solid #d3d3d3;
   border-radius: 5px;
 }
+
+.title {
+  font-size: 20px;
+  font-weight: 700;
+  padding-bottom: 0.5rem;
+}

--- a/src/pages/MyProfile.js
+++ b/src/pages/MyProfile.js
@@ -3,7 +3,7 @@ import ReservedMissionsList from '../components/missions/ReservedMissionsList';
 import MyProfileStyles from './MyProfile.module.css';
 
 const MyProfile = () => (
-  <div>
+  <div className="myProfileContainer">
     <div className={MyProfileStyles.pageContainer}>
       <div className={MyProfileStyles.missionsContainer}>
         <h2 className={MyProfileStyles.title}>My Missions</h2>

--- a/src/redux/missions/missionsSlice.js
+++ b/src/redux/missions/missionsSlice.js
@@ -18,13 +18,14 @@ export const getMissions = createAsyncThunk(
 
     response.data.forEach((obj) => {
       const {
-        mission_id, mission_name, description,
+        mission_id, mission_name, description, wikipedia,
       } = obj;
 
       const formatedData = {
         mission_id,
         mission_name,
         description,
+        wikipedia,
         reserved: false,
       };
 

--- a/src/redux/rockets/rocketsSlice.js
+++ b/src/redux/rockets/rocketsSlice.js
@@ -18,7 +18,7 @@ export const getRockets = createAsyncThunk(
 
     response.data.forEach((obj) => {
       const {
-        rocket_id, rocket_name, description, flickr_images,
+        rocket_id, rocket_name, description, flickr_images, wikipedia,
       } = obj;
 
       const formatedData = {
@@ -26,6 +26,7 @@ export const getRockets = createAsyncThunk(
         rocket_name,
         description,
         flickr_images,
+        wikipedia,
         reserved: false,
       };
 


### PR DESCRIPTION
# Additional Requirements

In this PR I added a placeholder message for the my-profile page when there are no missions or no rockets reservations, I also added a button to cancel a reservation for missions or for rockets and a button to read more about the mission or rocket that are reserved. 

### Additional requirements instructions 

- [x] Enhance the My Profile section by adding a placeholder message when the "My Missions" or "My Rockets" lists are empty (no missions joined or no rockets reserved).
- [x] Enhance the My Profile section by adding the "Cancel reservation" and "Leave Mission" buttons to the lists here. Clicking them should dispatch the actions you have already used in the main Rockets and Missions sections.
- [x] Enhance the My Profile section by adding the "Read more" button for each mission and rocket. Upon click, it should open a corresponding Wikipedia page in a new tab. NOTE - you need to get that extra Wikipedia URL from the API's payload.
